### PR TITLE
Add basic chat message UI

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -12,7 +12,10 @@
 	<div class="content">
 		<h1>This is a plain old website</h1>
 		<p>This is just a plain website that is using plain old JavaScript</p>
-		<button onclick="talkToTheHand()">Talk to the hand</button>
+        <button onclick="talkToTheHand()">Talk to the hand</button>
+        <div id="chat" class="chat">
+                <div id="messages" class="messages"></div>
+        </div>
 	</div>
 	<footer>
 		<p>Built with 🧡 on <a href="https://developers.cloudflare.com">Cloudflare Workers</a> and the <a href="https://platform.openai.com/docs/api-reference/realtime">OpenAI Realtime API</a></p>

--- a/public/script.js
+++ b/public/script.js
@@ -1,4 +1,13 @@
 const hand = new Hand();
+const messagesContainer = document.getElementById('messages');
+
+function addMessage(role, text) {
+        const div = document.createElement('div');
+        div.className = `message ${role}`;
+        div.textContent = text;
+        messagesContainer.appendChild(div);
+        messagesContainer.scrollTop = messagesContainer.scrollHeight;
+}
 
 function talkToTheHand() {
 	hand
@@ -109,9 +118,17 @@ dataChannel.addEventListener('open', (ev) => {
 // }
 
 dataChannel.addEventListener('message', async (ev) => {
-	const msg = JSON.parse(ev.data);
-	// Handle function calls
-	if (msg.type === 'response.function_call_arguments.done') {
+        const msg = JSON.parse(ev.data);
+        if (msg.type && msg.type.startsWith('transcript')) {
+                const text = msg.transcript || msg.text;
+                if (text) addMessage('user', text);
+        }
+        if (msg.type && msg.type.startsWith('response')) {
+                const text = msg.text || msg.delta;
+                if (text) addMessage('assistant', text);
+        }
+        // Handle function calls
+        if (msg.type === 'response.function_call_arguments.done') {
 		const fn = fns[msg.name];
 		if (fn !== undefined) {
 			console.log(`Calling local function ${msg.name} with ${msg.arguments}`);

--- a/public/styles.css
+++ b/public/styles.css
@@ -22,5 +22,34 @@ footer {
 }
 
 footer a {
-	color: #fff;
+        color: #fff;
+}
+
+/* Chat layout */
+.chat {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    margin-top: 1rem;
+}
+
+.messages {
+    overflow-y: auto;
+}
+
+.message {
+    max-width: 70%;
+    padding: 8px 12px;
+    border-radius: 12px;
+    margin-bottom: 4px;
+}
+
+.message.user {
+    align-self: flex-end;
+    background-color: #dcf8c6;
+}
+
+.message.assistant {
+    align-self: flex-start;
+    background-color: #eee;
 }


### PR DESCRIPTION
## Summary
- add a message container to index.html
- append transcript and response events as chat bubbles
- style chat bubbles like a typical messenger

## Testing
- `npm install`
- `npm test` *(fails: Snapshot mismatch)*

------
https://chatgpt.com/codex/tasks/task_b_684191c5e654832db8f487d0317f7a88