### PR TITLE
Update MCP endpoints and tests

### DIFF
--- a/test/mcp.spec.ts
+++ b/test/mcp.spec.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { fetchTools, triggerTool } from '../src/mcp';
+
+const BASE = 'http://mcp';
+
+describe('mcp helpers', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('fetchTools parses tool list', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ tools: [{ type: 'function', name: 'hand' }] }),
+    }) as unknown as typeof fetch;
+    vi.stubGlobal('fetch', mockFetch);
+
+    const tools = await fetchTools(BASE);
+
+    expect(mockFetch).toHaveBeenCalledWith(`${BASE}/v1/tool`);
+    expect(tools).toEqual([{ type: 'function', name: 'hand' }]);
+  });
+
+  it('triggerTool posts to invoke endpoint', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ result: { success: true } }),
+    }) as unknown as typeof fetch;
+    vi.stubGlobal('fetch', mockFetch);
+
+    const result = await triggerTool('hand', { move: 'up' }, BASE);
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      `${BASE}/v1/tool/hand/invoke`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ move: 'up' }),
+      },
+    );
+    expect(result).toEqual({ success: true });
+  });
+});


### PR DESCRIPTION
## Summary
- update MCP tool list and trigger URLs
- handle new MCP response shapes
- add tests covering MCP tool fetch and invocation

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_b_6841ae635aa4832db26bb64cbd1281aa