### PR TITLE
Add realtime controls and speech API

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Material Chat Demo</title>
   <link href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
   <link rel="stylesheet" href="/styles.css" />
 </head>
 <body class="blue-grey lighten-5">
@@ -14,8 +15,25 @@
     </div>
   </nav>
   <main class="container content">
+    <div class="section center">
+      <button id="realtime-toggle" class="btn-large waves-effect waves-light teal pulse">
+        <i id="realtime-icon" class="material-icons">play_arrow</i>
+      </button>
+    </div>
     <div class="section">
-      <button class="btn waves-effect waves-light" onclick="talkToTheHand()">Talk to the hand</button>
+      <div class="input-field">
+        <input type="text" id="voice-name" value="nova">
+        <label for="voice-name">Voice Name</label>
+      </div>
+      <div class="input-field">
+        <textarea id="voice-instructions" class="materialize-textarea"></textarea>
+        <label for="voice-instructions">Voice Instructions</label>
+      </div>
+      <div class="input-field">
+        <input type="text" id="speech-text" />
+        <label for="speech-text">Text to Pronounce</label>
+      </div>
+      <button id="speak-btn" class="btn waves-effect waves-light">Speak</button>
     </div>
     <div id="chat" class="chat">
       <div id="messages" class="messages"></div>

--- a/public/styles.css
+++ b/public/styles.css
@@ -55,3 +55,11 @@ footer a {
     align-self: flex-start;
     background-color: #eceff1;
 }
+
+#realtime-toggle {
+    width: 80px;
+    height: 80px;
+    border-radius: 50%;
+    font-size: 36px;
+    line-height: 80px;
+}

--- a/server.js
+++ b/server.js
@@ -12,23 +12,41 @@ In the tools you have the ability to control a robot hand.
 const app = express();
 app.use(cors());
 
+async function createSession(instructions, voice) {
+  const response = await fetch('https://api.openai.com/v1/realtime/sessions', {
+    method: 'POST',
+    headers: {
+      'Authorization': `Bearer ${process.env.OPENAI_API_KEY}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      model: 'gpt-4o-realtime-preview-2024-12-17',
+      instructions: instructions || DEFAULT_INSTRUCTIONS,
+      voice: voice || 'ash',
+    }),
+  });
+  return response.json();
+}
+
 app.get('/session', async (req, res) => {
   try {
     const toolsRes = await fetch(`${process.env.MCP_SERVER_URL}/tools`);
     const tools = await toolsRes.json();
-    const response = await fetch('https://api.openai.com/v1/realtime/sessions', {
-      method: 'POST',
-      headers: {
-        'Authorization': `Bearer ${process.env.OPENAI_API_KEY}`,
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
-        model: 'gpt-4o-realtime-preview-2024-12-17',
-        instructions: DEFAULT_INSTRUCTIONS,
-        voice: 'ash',
-      }),
-    });
-    const result = await response.json();
+    const { instructions, voice } = req.query;
+    const result = await createSession(instructions, voice);
+    res.json({ result, tools });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to create session' });
+  }
+});
+
+app.post('/session', express.json(), async (req, res) => {
+  try {
+    const { instructions, voice } = req.body || {};
+    const toolsRes = await fetch(`${process.env.MCP_SERVER_URL}/tools`);
+    const tools = await toolsRes.json();
+    const result = await createSession(instructions, voice);
     res.json({ result, tools });
   } catch (err) {
     console.error(err);
@@ -60,6 +78,35 @@ app.post('/tools/:name', express.json(), async (req, res) => {
   } catch (err) {
     console.error(err);
     res.status(500).json({ error: 'Failed to trigger tool' });
+  }
+});
+
+app.post('/speech', express.json(), async (req, res) => {
+  try {
+    const { text, voice = 'nova', instructions } = req.body || {};
+    const response = await fetch('https://api.openai.com/v1/audio/speech', {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${process.env.OPENAI_API_KEY}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        model: 'tts-1',
+        input: text,
+        voice,
+        ...(instructions ? { prompt: instructions } : {}),
+      }),
+    });
+    if (!response.ok) {
+      const errText = await response.text();
+      throw new Error(`Speech API error: ${response.status} - ${errText}`);
+    }
+    const buffer = await response.arrayBuffer();
+    res.set('Content-Type', 'audio/mpeg');
+    res.send(Buffer.from(buffer));
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to synthesize speech' });
   }
 });
 

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -28,6 +28,7 @@ describe('Hello World worker', () => {
 			  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 			  <title>Material Chat Demo</title>
 			  <link href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css" rel="stylesheet">
+			  <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 			  <link rel="stylesheet" href="/styles.css" />
 			</head>
 			<body class="blue-grey lighten-5">
@@ -37,8 +38,25 @@ describe('Hello World worker', () => {
 			    </div>
 			  </nav>
 			  <main class="container content">
+			    <div class="section center">
+			      <button id="realtime-toggle" class="btn-large waves-effect waves-light teal pulse">
+			        <i id="realtime-icon" class="material-icons">play_arrow</i>
+			      </button>
+			    </div>
 			    <div class="section">
-			      <button class="btn waves-effect waves-light" onclick="talkToTheHand()">Talk to the hand</button>
+			      <div class="input-field">
+			        <input type="text" id="voice-name" value="nova">
+			        <label for="voice-name">Voice Name</label>
+			      </div>
+			      <div class="input-field">
+			        <textarea id="voice-instructions" class="materialize-textarea"></textarea>
+			        <label for="voice-instructions">Voice Instructions</label>
+			      </div>
+			      <div class="input-field">
+			        <input type="text" id="speech-text" />
+			        <label for="speech-text">Text to Pronounce</label>
+			      </div>
+			      <button id="speak-btn" class="btn waves-effect waves-light">Speak</button>
 			    </div>
 			    <div id="chat" class="chat">
 			      <div id="messages" class="messages"></div>


### PR DESCRIPTION
## Summary
- add realtime toggle button and voice fields in the demo page
- expose POST `/session` and new `/speech` endpoint
- update client script to control realtime connection and speech synthesis
- expand styles for larger play button
- update integration test snapshot

## Testing
- `npm test -- -u`


------
https://chatgpt.com/codex/tasks/task_b_6841aeda8fd4832d8315eb622b2b887f