### PR TITLE
Add configurable realtime model

### DIFF
--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -1,3 +1,4 @@
 OPENAI_API_KEY="YOUR-API-KEY"
 
 MCP_SERVER_URL="http://localhost:3000"
+OPENAI_REALTIME_MODEL="gpt-4o-realtime-preview-2024-12-17"

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ This project is a [Cloudflare Workers](https://developers.cloudflare.com) app us
 
 ## Develop
 
-Copy [.dev.vars.example](./.dev.vars.example) to `.dev.vars` and set both `OPENAI_API_KEY` and `MCP_SERVER_URL`.
-`MCP_SERVER_URL` is used for fetching external tools (for example `http://localhost:3000`).
+Copy [.dev.vars.example](./.dev.vars.example) to `.dev.vars` and set `OPENAI_API_KEY`, `MCP_SERVER_URL`, and optionally `OPENAI_REALTIME_MODEL`.
+`MCP_SERVER_URL` is used for fetching external tools (for example `http://localhost:3000`). `OPENAI_REALTIME_MODEL` defaults to `gpt-4o-realtime-preview-2024-12-17`.
 
 Install your dependencies
 
@@ -48,7 +48,7 @@ gcloud run deploy tool-calls \
   --image gcr.io/PROJECT_ID/tool-calls \
   --platform managed \
   --region us-central1 \
-  --set-env-vars OPENAI_API_KEY=YOUR_OPENAI_KEY
+  --set-env-vars OPENAI_API_KEY=YOUR_OPENAI_KEY,OPENAI_REALTIME_MODEL=gpt-4o-realtime-preview-2024-12-17
 ```
 
-Replace `PROJECT_ID` with your Google Cloud project ID and provide your `OPENAI_API_KEY`.
+Replace `PROJECT_ID` with your Google Cloud project ID and provide your `OPENAI_API_KEY`. `OPENAI_REALTIME_MODEL` can be used to select a different model.

--- a/public/index.html
+++ b/public/index.html
@@ -31,6 +31,7 @@
     </div>
   </footer>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
+  <script>window.REALTIME_MODEL="gpt-4o-realtime-preview-2024-12-17"</script>
   <script src="/hand.js"></script>
   <script src="/script.js"></script>
 </body>

--- a/public/script.js
+++ b/public/script.js
@@ -185,7 +185,7 @@ async function startRealtime() {
         const data = await tokenResponse.json();
         const EPHEMERAL_KEY = data.result.client_secret.value;
         const baseUrl = 'https://api.openai.com/v1/realtime';
-        const model = 'gpt-4o-realtime-preview-2024-12-17';
+        const model = window.REALTIME_MODEL || 'gpt-4o-realtime-preview-2024-12-17';
         const r = await fetch(`${baseUrl}?model=${model}`, {
                 method: 'POST',
                 body: offer.sdp,

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,8 @@ app.get('/session', async (c) => {
         } catch (err) {
                 console.warn('Unable to fetch tools:', err);
         }
+        const model =
+                c.env.OPENAI_REALTIME_MODEL || 'gpt-4o-realtime-preview-2024-12-17';
         const response = await fetch('https://api.openai.com/v1/realtime/sessions', {
                 method: 'POST',
                 headers: {
@@ -25,7 +27,7 @@ app.get('/session', async (c) => {
                         'Content-Type': 'application/json',
                 },
                 body: JSON.stringify({
-                        model: 'gpt-4o-realtime-preview-2024-12-17',
+                        model,
                         instructions: DEFAULT_INSTRUCTIONS,
                         voice: 'ash',
                 }),

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -54,6 +54,7 @@ describe('Hello World worker', () => {
 			    </div>
 			  </footer>
 			  <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
+			  <script>window.REALTIME_MODEL="gpt-4o-realtime-preview-2024-12-17"</script>
 			  <script src="/hand.js"></script>
 			  <script src="/script.js"></script>
 			</body>

--- a/worker-configuration.d.ts
+++ b/worker-configuration.d.ts
@@ -3,4 +3,5 @@
 interface Env {
         OPENAI_API_KEY: string;
         MCP_SERVER_URL: string;
+        OPENAI_REALTIME_MODEL: string;
 }


### PR DESCRIPTION
## Summary
- add `OPENAI_REALTIME_MODEL` env in worker types
- provide default `OPENAI_REALTIME_MODEL` in `.dev.vars.example`
- read the model from config in `src/index.ts`
- expose the model to the browser and consume it in `public/script.js`
- document new env var in README
- update HTML snapshot

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6841c4cb0b50832daa4dc7e3af9d4421