### PR TITLE
Update README with realtime API details

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This project is a [Cloudflare Workers](https://developers.cloudflare.com) app using [Hono](https://honojs.dev) to relay the [OpenAI Realtime API](https://platform.openai.com/docs/api-reference/realtime) over WebRTC. The main files are just [static assets](https://developers.cloudflare.com/workers/static-assets/).
 
+The default model is `gpt-4o-realtime-preview-2025-06-03`, and the application now relies solely on the OpenAI Realtime API for both speech recognition and speech synthesis.
+
 [<img src="https://img.youtube.com/vi/TcOytsfva0o/0.jpg">](https://youtu.be/TcOytsfva0o "Client Side Tool Calling with the OpenAI WebRTC Realtime API")
 
 


### PR DESCRIPTION
## Summary
- document the new default realtime model

## Testing
- `npx --yes vitest run`


------
https://chatgpt.com/codex/tasks/task_b_6841d8e62e48832db739395ee29312f0