### PR TITLE
Remove voice param in realtime session

### DIFF
--- a/server.js
+++ b/server.js
@@ -30,7 +30,6 @@ app.get('/session', async (req, res) => {
       body: JSON.stringify({
         model: 'gpt-4o-realtime-preview-2025-06-03',
         instructions: DEFAULT_INSTRUCTIONS,
-        voice: 'nova',
       }),
     });
     const result = await response.json();

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,6 @@ app.get('/session', async (c) => {
                 body: JSON.stringify({
                         model,
                         instructions: DEFAULT_INSTRUCTIONS,
-                        voice: 'nova',
                 }),
         });
         const result = await response.json();


### PR DESCRIPTION
## Summary
- remove the `voice` field from the realtime session requests so the API does not error

## Testing
- `npm test`
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6841e240d4bc832d969a24a16990ef13