### PR TITLE
Handle missing tool server when creating session

### DIFF
--- a/server.js
+++ b/server.js
@@ -15,12 +15,18 @@ const app = express();
 app.use(cors());
 
 app.get('/session', async (req, res) => {
+  let tools = [];
   try {
     const toolsRes = await fetch(`${MCP_SERVER_URL}/v1/tool`);
     const toolsData = await toolsRes.json();
-    const tools = Array.isArray(toolsData)
+    tools = Array.isArray(toolsData)
       ? toolsData
       : toolsData.tools ?? toolsData.data ?? [];
+  } catch (err) {
+    console.warn('Unable to fetch tools:', err);
+  }
+
+  try {
     const response = await fetch('https://api.openai.com/v1/realtime/sessions', {
       method: 'POST',
       headers: {


### PR DESCRIPTION
## Summary
- avoid failing `/session` when the MCP tool server is unreachable

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6841e2ca87c8832db6278c5e09c132f4