### PR TITLE
Add tool panel buttons and MCP mock server

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ Install your dependencies
 npm install
 ```
 
+Start the mock MCP server in a separate terminal to provide placeholder tools:
+
+```bash
+npm run mcp
+```
+
 Run local server
 
 ```bash

--- a/mock-mcp-server.js
+++ b/mock-mcp-server.js
@@ -1,0 +1,48 @@
+import express from 'express';
+import cors from 'cors';
+
+const app = express();
+app.use(cors());
+app.use(express.json());
+
+const tools = [
+  {
+    type: 'function',
+    name: 'helloWorld',
+    description: 'Returns a friendly greeting',
+    parameters: {
+      type: 'object',
+      properties: {
+        name: { type: 'string', description: 'Name to greet' }
+      },
+    },
+  },
+  {
+    type: 'function',
+    name: 'echo',
+    description: 'Echos back whatever is provided',
+    parameters: {
+      type: 'object',
+      additionalProperties: true,
+    },
+  },
+];
+
+app.get('/v1/tool', (req, res) => {
+  res.json({ tools });
+});
+
+app.post('/v1/tool/:name/invoke', (req, res) => {
+  const { name } = req.params;
+  const args = req.body || {};
+  if (name === 'helloWorld') {
+    const person = args.name || 'World';
+    return res.json({ result: `Hello, ${person}!` });
+  }
+  res.json({ result: args });
+});
+
+const port = process.env.MCP_PORT || 3000;
+app.listen(port, () => {
+  console.log(`Mock MCP server listening on port ${port}`);
+});

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "dev": "wrangler dev",
     "start": "node server.js",
     "test": "vitest",
-    "cf-typegen": "wrangler types"
+    "cf-typegen": "wrangler types",
+    "mcp": "node mock-mcp-server.js"
   },
   "devDependencies": {
     "@cloudflare/vitest-pool-workers": "^0.5.2",

--- a/public/script.js
+++ b/public/script.js
@@ -265,7 +265,23 @@ document.addEventListener('DOMContentLoaded', async () => {
         list.innerHTML = '';
         tools.forEach((tool) => {
             const li = document.createElement('li');
-            li.textContent = tool.name;
+            const button = document.createElement('button');
+            button.textContent = tool.name;
+            button.className = 'btn waves-effect waves-light tool-button';
+            button.addEventListener('click', async () => {
+                try {
+                    const resp = await fetch(`/tools/${tool.name}`, {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({}),
+                    });
+                    const data = await resp.json();
+                    console.log('Tool result', data);
+                } catch (err) {
+                    console.error('Failed to invoke tool', err);
+                }
+            });
+            li.appendChild(button);
             list.appendChild(li);
         });
     }

--- a/public/styles.css
+++ b/public/styles.css
@@ -54,9 +54,11 @@ body {
 }
 
 .tools-panel li {
-    padding: 8px;
-    border-radius: 4px;
     margin-bottom: 4px;
+}
+
+.tools-panel button.tool-button {
+    width: 100%;
     background-color: var(--md-primary-container);
     color: var(--md-on-primary-container);
 }


### PR DESCRIPTION
## Summary
- render tools as buttons in the sidebar
- call the `/tools/:name` endpoint when a tool button is clicked
- style the tool buttons
- add a mock MCP server with placeholder tools
- expose `npm run mcp` for running the mock MCP server
- document how to start the mock MCP server

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68420d56da34832d8671b885d91713cc