### PR TITLE
Fix realtime session error handling

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -33,8 +33,9 @@
 						<option value="alloy">alloy</option>
 						<option value="echo">echo</option>
 						<option value="fable">fable</option>
-						<option value="shimmer">shimmer</option>
-					</select>
+                                                <option value="shimmer">shimmer</option>
+                                                <option value="ash">ash</option>
+                                        </select>
 					<button id="random-voice" class="btn waves-effect waves-light">Random Voice</button>
 				</div>
 				<div class="model-select">

--- a/public/script.js
+++ b/public/script.js
@@ -6,7 +6,7 @@ let dataChannel;
 let mediaStream;
 let currentAssistantEl;
 let availableTools = [];
-const VOICES = ['nova', 'onyx', 'alloy', 'echo', 'fable', 'shimmer'];
+const VOICES = ['nova', 'onyx', 'alloy', 'echo', 'fable', 'shimmer', 'ash'];
 const MODELS = ['gpt-4o-realtime-preview-2025-06-03', 'gpt-4o-realtime-preview-2024-12-17'];
 const EXAMPLE_INSTRUCTIONS = `# Personality and Tone
 ## Identity
@@ -289,8 +289,15 @@ async function startRealtime() {
 			showNotification('Failed to start session', false);
 			throw new Error('Session request failed');
 		}
-		const data = await tokenResponse.json();
-		const EPHEMERAL_KEY = data.result.client_secret.value;
+                const data = await tokenResponse.json();
+                const ephemeralKey = data?.result?.client_secret?.value;
+                if (!ephemeralKey) {
+                        console.error('Invalid session response', data);
+                        const message = data?.result?.error?.message || 'Failed to start session';
+                        showNotification(message, false);
+                        throw new Error('Session response invalid');
+                }
+                const EPHEMERAL_KEY = ephemeralKey;
 		const baseUrl = 'https://api.openai.com/v1/realtime';
 		const model = window.REALTIME_MODEL || 'gpt-4o-realtime-preview-2025-06-03';
 		const voice = voiceSelect ? voiceSelect.value : 'nova';


### PR DESCRIPTION
## Summary
- handle invalid session data so startRealtime doesn't throw
- add `ash` to voice options

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6842cfb37918832d85f3dc9d8da9937f